### PR TITLE
one doc typo and two code typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Super simple to use
 
-Filed does a lazy stat call so you can actually open a file and being writing to it and if the file isn't there it will just be created.
+Filed does a lazy stat call so you can actually open a file and begin writing to it and if the file isn't there it will just be created.
 
 ```javascript
 var filed = require('filed');
@@ -65,7 +65,7 @@ http.createServer(function (req, resp) {
 })
 ```
 
-The Etag and Last-Modified headers filed creates are based solely on the stat() call so if you pipe a request to an existing file the cache control headers will be taken in to account a 304 response will be sent if the cache control headers match a new stat() call. This can be very helpful in avoiding unnecessary disc reads.
+The Etag and Last-Modified headers filed creates are based solely on the stat() call so if you pipe a request to an existing file the cache control headers will be taken into account; a 304 response will be sent if the cache control headers match a new stat() call. This can be very helpful in avoiding unnecessary disc reads.
 
 ```javascript
 http.createServer(function (req, resp) {

--- a/main.js
+++ b/main.js
@@ -91,7 +91,7 @@ function File (options) {
           if (self.src && self.src.headers) {
             if (self.src.headers['if-none-match'] === self.etag ||
                 // Lazy last-modifed matching but it's faster than parsing Datetime
-                self.src.headers['if-modifified-since'] === self.lastmodified) {
+                self.src.headers['if-modified-since'] === self.lastmodified) {
               self.dest.statusCode = 304
               self.dest.end()
               return

--- a/test.js
+++ b/test.js
@@ -166,7 +166,7 @@ function testhttp () {
     request.get(url+'/test-lastmodified-wo', function (e, resp, body) {
       if (e) throw e
       if (resp.statusCode !== 200) throw new Error('Status code is not 200 it is '+resp.statusCode)
-      request.get({url:url+'/test-lastmodified-with', headers:{'if-modifified-since':resp.headers['last-modified']}}, function (e, resp) {
+      request.get({url:url+'/test-lastmodified-with', headers:{'if-modified-since':resp.headers['last-modified']}}, function (e, resp) {
         if (e) throw e
         if (resp.statusCode !== 304) throw new Error('Status code is not 304 it is '+resp.statusCode)
         console.log("Passed GET with if-modified-since")


### PR DESCRIPTION
Minor typos in README.md

"if-modified-since" was mis-spelled "if-modifified-since" in both main.js and test.js , so they matched but likely weren't as desired?

BTW: why is there both ./test.js and ./test-server.js , and test/test.js and test/server.js ?  Which is the 'correct' test ?  I've only updated ./test.js here.
