### PR TITLE
When piping to a response, and an error occurs, end the response

### DIFF
--- a/main.js
+++ b/main.js
@@ -72,10 +72,10 @@ function File (options) {
          ) {
         if (err.code === 'ENOENT') {
           self.dest.statusCode = 404
-          self.end('Not Found')
+          self.dest.end('Not Found')
         } else {
           self.dest.statusCode = 500
-          self.end(err.message)
+          self.dest.end(err.message)
         }
         return
       }


### PR DESCRIPTION
For the moment the samples in documentation won't work with unexisting files. In those cases, the stream is ended, but not the response.
Plus, as there is no data passed with the "end" event of the stream, there is no clean way to detect _why_ it has been ended and then properly end the response on the other side.
So I propose to end the response directly (as expected from documentation), when such an error occurs.
