### PR TITLE
Create a WriteStream instead of emitting an error on non-existing file

### DIFF
--- a/main.js
+++ b/main.js
@@ -43,6 +43,7 @@ function File (options) {
   fs.stat(options.path, function (err, stats) {
 
     var finish = function (err, stats) {
+      if (err && err.code === 'ENOENT' && !self.dest && !self.src) self.src = self.path
       if (err && !self.dest && !self.src) return self.emit('error', err)
       if (err && self.dest && !self.dest.writeHead) return self.emit('error', err)
 


### PR DESCRIPTION
Create a WriteStream instead of emitting an error when calling `filed("non-existing-file")`. Beware this will stick to documentation, but it will create a file (as `fs.createWriteStream` does).

REFS #8
