### PR TITLE
add missing 'content-length' header for HTTP responses.

### DIFF
--- a/main.js
+++ b/main.js
@@ -135,6 +135,7 @@ function File (options) {
         self.dest.setHeader('content-type', self.mimetype)
         self.dest.setHeader('etag', self.etag)
         self.dest.setHeader('last-modified', self.lastmodified)
+        self.dest.setHeader('content-length', stats.size)
         fs.createReadStream(self.path).pipe(self.dest)
         return
       }


### PR DESCRIPTION
according to the README,

```
Not only does the JSON file get streamed to the HTTP Response it will include an Etag, Last-Modified, Content-Length, and a Content-Type header based on the filed extension.
```

but only three of these headers are being sent right now; `Content-Length` is missing.
