### PR TITLE
Makes `mime` dependency stick to v1.2.6 always

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "license": "ASL 2.0",
   "dependencies": {
-    "mime": ">= 1.2.6"
+    "mime": "1.2.6"
   },
   "scripts": {
     "test": "node test/test.js"


### PR DESCRIPTION
The package `mime`has been updated to v2.0.0 with breaking changes that removes the `.lookup` method and renames it to `.getType`. The packages depending in this package are breaking because when using it, it dispatches this error (in this case, when trying to use `dpd-dashboard`):

```
TypeError: mime.lookup is not a function
at new File (/usr/src/app/node_modules/filed/main.js:33:44)
at module.exports (/usr/src/app/node_modules/filed/main.js:201:10)
at Dashboard.handle (/usr/src/app/node_modules/dpd-dashboard/dashboard.js:36:5)
at /usr/src/app/node_modules/deployd/lib/router.js:81:22
at _combinedTickCallback (internal/process/next_tick.js:131:7)
at process._tickDomainCallback (internal/process/next_tick.js:218:9)
```

An `npm ls` in the `filed` dependency folder proves that:

```
/usr/src/app/node_modules/filed # npm ls
filed@0.1.0 /usr/src/app/node_modules/filed
`-- mime@2.0.3
```

This modification makes the project sticks to 1.2.6 no matter what, so it won't break with v2.0.0 updates.